### PR TITLE
`MdiIcons` as `abstract class`

### DIFF
--- a/packages/builder/lib/src/data/builder/mdi_icons_enum.dart
+++ b/packages/builder/lib/src/data/builder/mdi_icons_enum.dart
@@ -62,166 +62,110 @@ class MdiIconsEnum {
     return input;
   }
 
-  Enum generateEnumDefinition(Iterable<IconMetadata> metadataList) {
+  Class generateClassDefinition(Iterable<IconMetadata> metadataList) {
     final mdiMetadataClass = MdiMetadataClass();
 
-    return Enum(
+    final iconFields = metadataList.map(
+      (metadata) {
+        final name = _escapeKeyword(_kebabToLowerCamel(metadata.name));
+        return Field(
+          (b) => b
+            ..name = name
+            ..static = true
+            ..modifier = FieldModifier.constant
+            ..type = refer('IconData', 'package:flutter/widgets.dart')
+            ..assignment = refer('IconData', 'package:flutter/widgets.dart')
+                .newInstance([
+              literalNum(int.parse('0x${metadata.codepoint}')),
+            ], {
+              'fontFamily': literalString('Material Design Icons'),
+              'fontPackage': literalString('flutter_material_design_icons'),
+              'matchTextDirection': literalBool(false),
+            }).code
+            ..docs.addAll([
+              '/// **${metadata.name}**',
+              '///',
+              '/// ![Icon preview](https://fafre.github.io/flutter_material_design_icons/icons/${metadata.name}/${metadata.version}/64.png "${metadata.name}")',
+              '///',
+              '///',
+              '/// *Author: ${metadata.author}*',
+              '///',
+              '/// *Version: ${metadata.version}*',
+              '///',
+              if (metadata.tags.isNotEmpty) ...[
+                '/// *Tags: ${metadata.tags.join(', ')}*',
+                '///',
+              ],
+              if (metadata.styles.isNotEmpty) ...[
+                '/// *Styles: ${metadata.styles.join(', ')}*',
+                '///',
+              ],
+            ])
+            ..annotations.addAll([
+              if (metadata.deprecated)
+                refer('Deprecated').call([
+                  literalString(
+                    'This icon has been marked as deprecated by the Material Design Icons project',
+                  )
+                ])
+            ]),
+        );
+      },
+    ).toList();
+
+    final valuesField = Field(
+      (b) => b
+        ..name = 'values'
+        ..static = true
+        ..modifier = FieldModifier.constant
+        ..type = refer('List<IconData>')
+        ..assignment = literalList(
+          iconFields.map((f) => refer(f.name)).toList(),
+        ).code,
+    );
+
+    final metadataMapField = Field(
+      (b) => b
+        ..name = 'metadata'
+        ..static = true
+        ..modifier = FieldModifier.constant
+        ..type = refer('Map<IconData, MdiMetadata>')
+        ..assignment = literalMap(
+          Map.fromEntries(
+            metadataList.map(
+              (metadata) => MapEntry(
+                refer(_escapeKeyword(_kebabToLowerCamel(metadata.name))),
+                mdiMetadataClass.generateInstance(metadata),
+              ),
+            ),
+          ),
+        ).code,
+    );
+
+    return Class(
       (b) => b
         ..name = 'MdiIcons'
-        ..implements.add(refer('IconData', 'package:flutter/widgets.dart'))
+        ..abstract = true
         ..fields.addAll([
-          Field(
-            (b) => b
-              ..name = 'codePoint'
-              ..type = refer('int')
-              ..modifier = FieldModifier.final$
-              ..annotations.add(refer('override'))
-              ..docs.addAll([
-                '/// The Unicode code point at which this icon is stored in the icon font.'
-              ]),
-          ),
-          Field(
-            (b) => b
-              ..name = 'matchTextDirection'
-              ..type = refer('bool')
-              ..modifier = FieldModifier.final$
-              ..annotations.add(refer('override'))
-              ..docs.addAll([
-                '/// Whether this icon should be automatically mirrored in right-to-left',
-                '/// environments.',
-                '///',
-                '/// The [Icon] widget respects this value by mirroring the icon when the',
-                '/// [Directionality] is [TextDirection.rtl].',
-              ]),
-          ),
-          Field(
-            (b) => b
-              ..name = 'metadata'
-              ..type = refer(mdiMetadataClass.classDefinition.name)
-              ..modifier = FieldModifier.final$,
-          ),
-          Field(
-            (b) => b
-              ..name = 'fontFamily'
-              ..type = refer('String')
-              ..modifier = FieldModifier.final$
-              ..annotations.add(refer('override'))
-              ..docs.addAll([
-                '/// The font family from which the glyph for the [codePoint] will be selected.'
-              ])
-              ..assignment = literalString('Material Design Icons').code,
-          ),
-          Field(
-            (b) => b
-              ..name = 'fontFamilyFallback'
-              ..type = refer('List<String>?')
-              ..modifier = FieldModifier.final$
-              ..annotations.add(refer('override'))
-              ..docs.addAll([
-                '/// The ordered list of font families to fall back on when a glyph cannot be found in a higher priority font family.',
-                '///',
-                '/// For more details, refer to the documentation of [TextStyle]',
-              ])
-              ..assignment = literalNull.code,
-          ),
-          Field(
-            (b) => b
-              ..name = 'fontPackage'
-              ..type = refer('String')
-              ..modifier = FieldModifier.final$
-              ..annotations.add(refer('override'))
-              ..docs.addAll([
-                '/// The name of the package from which the font family is included.',
-                '///',
-                '/// The name is used by the [Icon] widget when configuring the [TextStyle] so',
-                '/// that the given [fontFamily] is obtained from the appropriate asset.',
-                '///',
-                '/// See also:',
-                '///',
-                '///  * [TextStyle], which describes how to use fonts from other packages.',
-              ])
-              ..assignment =
-                  literalString('flutter_material_design_icons').code,
-          ),
-        ])
-        ..methods.addAll([
+          ...iconFields,
+          valuesField,
+          metadataMapField,
+        ]),
+    );
+  }
+
+  Extension generateExtensionDefinition() {
+    return Extension(
+      (b) => b
+        ..name = 'MdiIconsExtension'
+        ..on = refer('IconData', 'package:flutter/widgets.dart')
+        ..methods.add(
           Method(
             (b) => b
-              ..name = 'toString'
-              ..returns = refer('String')
-              ..lambda = true
-              ..annotations.add(refer('override'))
-              ..body = const Code(
-                r"'MdiIconData(U+${codePoint.toRadixString(16).toUpperCase().padLeft(5, '0')})'",
-              ),
-          )
-        ])
-        ..constructors.add(
-          Constructor(
-            (b) => b
-              ..constant = true
-              ..optionalParameters.addAll([
-                Parameter(
-                  (b) => b
-                    ..name = 'codePoint'
-                    ..named = true
-                    ..required = true
-                    ..toThis = true,
-                ),
-                Parameter(
-                  (b) => b
-                    ..name = 'metadata'
-                    ..named = true
-                    ..required = true
-                    ..toThis = true,
-                ),
-                Parameter(
-                  (b) => b
-                    ..name = 'matchTextDirection'
-                    ..named = true
-                    ..defaultTo = const Code('false')
-                    ..toThis = true,
-                )
-              ]),
-          ),
-        )
-        ..values.addAll(
-          metadataList.map(
-            (metadata) => EnumValue(
-              (b) => b
-                ..name = _escapeKeyword(_kebabToLowerCamel(metadata.name))
-                ..namedArguments.addAll({
-                  'codePoint': literalNum(int.parse('0x${metadata.codepoint}')),
-                  'metadata': mdiMetadataClass.generateInstance(metadata)
-                })
-                ..docs.addAll([
-                  '/// **${metadata.name}**',
-                  '///',
-                  '/// ![Icon preview](https://fafre.github.io/flutter_material_design_icons/icons/${metadata.name}/${metadata.version}/64.png "${metadata.name}")',
-                  '///',
-                  '///',
-                  '/// *Author: ${metadata.author}*',
-                  '///',
-                  '/// *Version: ${metadata.version}*',
-                  '///',
-                  if (metadata.tags.isNotEmpty) ...[
-                    '/// *Tags: ${metadata.tags.join(', ')}*',
-                    '///',
-                  ],
-                  if (metadata.styles.isNotEmpty) ...[
-                    '/// *Styles: ${metadata.styles.join(', ')}*',
-                    '///',
-                  ],
-                ])
-                ..annotations.addAll([
-                  if (metadata.deprecated)
-                    refer('Deprecated').call([
-                      literalString(
-                        'This icon has been marked as deprecated by the Material Design Icons project',
-                      )
-                    ])
-                ]),
-            ),
+              ..name = 'metadata'
+              ..type = MethodType.getter
+              ..returns = refer('MdiMetadata?')
+              ..body = refer('MdiIcons.metadata').index(refer('this')).code,
           ),
         ),
     );

--- a/packages/builder/lib/src/icon_builder.dart
+++ b/packages/builder/lib/src/icon_builder.dart
@@ -35,7 +35,8 @@ class IconDataGenerator extends Generator {
           ])
           ..body.addAll([
             MdiMetadataClass().classDefinition,
-            const MdiIconsEnum().generateEnumDefinition(metadataList),
+            const MdiIconsEnum().generateClassDefinition(metadataList),
+            const MdiIconsEnum().generateExtensionDefinition(),
           ]),
       );
 

--- a/packages/material_design_icons/README.md
+++ b/packages/material_design_icons/README.md
@@ -30,7 +30,7 @@ The app is available for web [here](https://fafre.github.io/flutter_material_des
 
 - **Iterable**
 
-  The icons are structured as an `enum` and can therefore be easily itegrated via `MdiIcons.values` for further processing or filtering in your application.
+  The icons are structured as an `abstract class` with `static const IconData` members and can therefore be easily integrated via `MdiIcons.values` for further processing or filtering in your application.
 
 ## Usage
 

--- a/packages/material_design_icons/example/lib/main.dart
+++ b/packages/material_design_icons/example/lib/main.dart
@@ -86,7 +86,7 @@ class FilterBar extends HookConsumerWidget {
                     ),
                   );
                 },
-              )
+              ),
             ],
           ),
         ),
@@ -100,7 +100,7 @@ class FilterBar extends HookConsumerWidget {
                 ? const Icon(Icons.expand_less)
                 : const Icon(Icons.expand_more),
           ),
-        )
+        ),
       ],
     );
   }
@@ -118,7 +118,7 @@ class MouseDragScrollBehavior extends MaterialScrollBehavior {
 class MainApp extends StatelessWidget {
   const MainApp({super.key});
 
-  Widget _buildIconInfo(BuildContext context, MdiIcons icon) {
+  Widget _buildIconInfo(BuildContext context, IconData icon) {
     return Tooltip(
       message: [
         'Author: ${icon.metadata.author}',
@@ -186,7 +186,7 @@ class MainApp extends StatelessWidget {
                                       textSearchNotifier.clear();
                                     },
                                     icon: const Icon(Icons.clear),
-                                  )
+                                  ),
                                 ]
                               : null,
                           onChanged: (value) {
@@ -212,7 +212,7 @@ class MainApp extends StatelessWidget {
                   const Divider(),
                 ],
               ),
-            )
+            ),
           ],
           body: HookConsumer(
             builder: (context, ref, child) {


### PR DESCRIPTION
Exploration to address:

* https://github.com/flutter/flutter/issues/181342

This PR explores option 1 from https://github.com/FaFre/WebLibre/issues/214#issuecomment-4030251844

Breaking changes:

* `MdiIcons` cannot be used as a meaningful type, so the type should be replaced with `IconData`.